### PR TITLE
cmd,collector: optionally disable concurrent scrapes

### DIFF
--- a/cmd/postgres_exporter/main.go
+++ b/cmd/postgres_exporter/main.go
@@ -15,9 +15,11 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus-community/postgres_exporter/collector"
@@ -31,6 +33,65 @@ import (
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
 )
+
+func registerPostgresCollector(dsn string, exporter *Exporter, logger *slog.Logger, excludedDatabases []string, scrapeTimeout time.Duration, concurrentScrape bool) {
+	if dsn == "" {
+		return
+	}
+
+	var instance *collector.Instance
+	var opts []collector.Option
+
+	if concurrentScrape {
+		// Original behavior: dedicated instance for collector, creates new connection per scrape
+		inst, err := collector.NewInstance(dsn)
+		if err != nil {
+			logger.Warn("Failed to create instance", "err", err.Error())
+			return
+		}
+		instance = inst
+		// Add option to create new instance per collect
+		opts = append(opts, collector.WithInstancePerCollect())
+	} else {
+		// New optimized behavior: share connection from server
+		server, err := exporter.servers.GetServer(dsn)
+		if err != nil {
+			logger.Warn("Failed to get server for collectors", "err", err.Error())
+			return
+		}
+
+		inst, err := collector.NewInstance(dsn)
+		if err != nil {
+			logger.Warn("Failed to create instance", "err", err.Error())
+			return
+		}
+
+		err = inst.SetupWithConnection(server.db)
+		if err != nil {
+			logger.Warn("Failed to setup shared instance", "err", err.Error())
+			return
+		}
+		instance = inst
+	}
+
+	// Add timeout option
+	opts = append(opts, collector.WithTimeout(scrapeTimeout))
+
+	// Create collector
+	pe, err := collector.NewPostgresCollector(
+		logger,
+		excludedDatabases,
+		instance,
+		[]string{},
+		opts...,
+	)
+	if err != nil {
+		logger.Warn("Failed to create PostgresCollector", "err", err.Error())
+		return
+	}
+
+	prometheus.MustRegister(pe)
+}
 
 var (
 	c = config.Handler{
@@ -50,6 +111,7 @@ var (
 	includeDatabases       = kingpin.Flag("include-databases", "A list of databases to include when autoDiscoverDatabases is enabled (DEPRECATED)").Default("").Envar("PG_EXPORTER_INCLUDE_DATABASES").String()
 	metricPrefix           = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
 	scrapeTimeout          = kingpin.Flag("scrape.timeout", "Maximum time for a scrape to complete before timing out (0 = no timeout)").Default("0").Envar("PG_EXPORTER_SCRAPE_TIMEOUT").Duration()
+	concurrentScrape       = kingpin.Flag("concurrent-scrape", "Use dedicated instance for collector allowing concurrent scrapes (default: true for backward compatibility)").Default("true").Envar("PG_EXPORTER_CONCURRENT_SCRAPE").Bool()
 	logger                 = promslog.NewNopLogger()
 )
 
@@ -133,38 +195,7 @@ func main() {
 		dsn = dsns[0]
 	}
 
-	if dsn != "" {
-		// Get the server connection to share with collectors
-		server, err := exporter.servers.GetServer(dsn)
-		if err != nil {
-			logger.Warn("Failed to get server for collectors", "err", err.Error())
-		} else {
-			// Create instance with shared connection from server
-			instance, err := collector.NewInstance(dsn)
-			if err != nil {
-				logger.Warn("Failed to create instance", "err", err.Error())
-			} else {
-				err = instance.SetupWithConnection(server.db)
-				if err != nil {
-					logger.Warn("Failed to setup shared instance", "err", err.Error())
-				} else {
-					// Create collector with shared instance (instancePerCollect defaults to false)
-					pe, err := collector.NewPostgresCollector(
-						logger,
-						excludedDatabases,
-						instance,
-						[]string{},
-						collector.WithTimeout(*scrapeTimeout),
-					)
-					if err != nil {
-						logger.Warn("Failed to create PostgresCollector", "err", err.Error())
-					} else {
-						prometheus.MustRegister(pe)
-					}
-				}
-			}
-		}
-	}
+	registerPostgresCollector(dsn, exporter, logger, excludedDatabases, *scrapeTimeout, *concurrentScrape)
 
 	http.Handle(*metricsPath, promhttp.Handler())
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -93,7 +93,8 @@ type PostgresCollector struct {
 	logger        *slog.Logger
 	scrapeTimeout time.Duration
 
-	instance *instance
+	instance           *instance
+	instancePerCollect bool
 }
 
 type Option func(*PostgresCollector) error
@@ -106,10 +107,19 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithInstancePerCollect configures whether to create a new instance per Collect call.
+func WithInstancePerCollect() Option {
+	return func(p *PostgresCollector) error {
+		p.instancePerCollect = true
+		return nil
+	}
+}
+
 // NewPostgresCollector creates a new PostgresCollector.
-func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, dsn string, filters []string, options ...Option) (*PostgresCollector, error) {
+func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, instance *instance, filters []string, options ...Option) (*PostgresCollector, error) {
 	p := &PostgresCollector{
-		logger: logger,
+		logger:   logger,
+		instance: instance,
 	}
 	// Apply options to customize the collector
 	for _, o := range options {
@@ -154,16 +164,6 @@ func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, dsn st
 
 	p.Collectors = collectors
 
-	if dsn == "" {
-		return nil, errors.New("empty dsn")
-	}
-
-	instance, err := newInstance(dsn)
-	if err != nil {
-		return nil, err
-	}
-	p.instance = instance
-
 	return p, nil
 }
 
@@ -184,15 +184,21 @@ func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 		ctx = context.Background()
 	}
 
-	// copy the instance so that concurrent scrapes have independent instances
-	inst := p.instance.copy()
-
-	// Set up the database connection for the collector.
-	err := inst.setup()
-	defer inst.Close()
-	if err != nil {
-		p.logger.Error("Error opening connection to database", "err", err)
-		return
+	var inst *instance
+	
+	if p.instancePerCollect {
+		// copy the instance so that concurrent scrapes have independent instances
+		inst = p.instance.copy()
+		// Set up the database connection for the collector.
+		err := inst.setup()
+		if err != nil {
+			p.logger.Error("Error opening connection to database", "err", err)
+			return
+		}
+		defer inst.Close()
+	} else {
+		// Use the shared instance directly
+		inst = p.instance
 	}
 
 	wg := sync.WaitGroup{}
@@ -204,10 +210,6 @@ func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 		}(name, c)
 	}
 	wg.Wait()
-}
-
-func (p *PostgresCollector) Close() error {
-	return p.instance.Close()
 }
 
 func execute(ctx context.Context, name string, c Collector, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -59,7 +59,7 @@ var (
 )
 
 type Collector interface {
-	Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error
+	Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error
 }
 
 type collectorConfig struct {
@@ -93,7 +93,7 @@ type PostgresCollector struct {
 	logger        *slog.Logger
 	scrapeTimeout time.Duration
 
-	instance           *instance
+	instance           *Instance
 	instancePerCollect bool
 }
 
@@ -116,7 +116,7 @@ func WithInstancePerCollect() Option {
 }
 
 // NewPostgresCollector creates a new PostgresCollector.
-func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, instance *instance, filters []string, options ...Option) (*PostgresCollector, error) {
+func NewPostgresCollector(logger *slog.Logger, excludeDatabases []string, instance *Instance, filters []string, options ...Option) (*PostgresCollector, error) {
 	p := &PostgresCollector{
 		logger:   logger,
 		instance: instance,
@@ -184,7 +184,7 @@ func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 		ctx = context.Background()
 	}
 
-	var inst *instance
+	var inst *Instance
 	
 	if p.instancePerCollect {
 		// copy the instance so that concurrent scrapes have independent instances
@@ -212,7 +212,7 @@ func (p PostgresCollector) Collect(ch chan<- prometheus.Metric) {
 	wg.Wait()
 }
 
-func execute(ctx context.Context, name string, c Collector, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) {
+func execute(ctx context.Context, name string, c Collector, instance *Instance, ch chan<- prometheus.Metric, logger *slog.Logger) {
 	begin := time.Now()
 	err := c.Update(ctx, instance, ch)
 	duration := time.Since(begin)

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -27,7 +27,7 @@ type instance struct {
 	version semver.Version
 }
 
-func newInstance(dsn string) (*instance, error) {
+func NewInstance(dsn string) (*instance, error) {
 	i := &instance{
 		dsn: dsn,
 	}
@@ -65,6 +65,18 @@ func (i *instance) setup() error {
 	} else {
 		i.version = version
 	}
+	return nil
+}
+
+// SetupWithConnection sets up the instance with an existing database connection.
+func (i *instance) SetupWithConnection(db *sql.DB) error {
+	i.db = db
+	
+	version, err := queryVersion(i.db)
+	if err != nil {
+		return fmt.Errorf("error querying postgresql version: %w", err)
+	}
+	i.version = version
 	return nil
 }
 

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -21,14 +21,14 @@ import (
 	"github.com/blang/semver/v4"
 )
 
-type instance struct {
+type Instance struct {
 	dsn     string
 	db      *sql.DB
 	version semver.Version
 }
 
-func NewInstance(dsn string) (*instance, error) {
-	i := &instance{
+func NewInstance(dsn string) (*Instance, error) {
+	i := &Instance{
 		dsn: dsn,
 	}
 
@@ -44,13 +44,13 @@ func NewInstance(dsn string) (*instance, error) {
 }
 
 // copy returns a copy of the instance.
-func (i *instance) copy() *instance {
-	return &instance{
+func (i *Instance) copy() *Instance {
+	return &Instance{
 		dsn: i.dsn,
 	}
 }
 
-func (i *instance) setup() error {
+func (i *Instance) setup() error {
 	db, err := sql.Open("postgres", i.dsn)
 	if err != nil {
 		return err
@@ -69,9 +69,9 @@ func (i *instance) setup() error {
 }
 
 // SetupWithConnection sets up the instance with an existing database connection.
-func (i *instance) SetupWithConnection(db *sql.DB) error {
+func (i *Instance) SetupWithConnection(db *sql.DB) error {
 	i.db = db
-	
+
 	version, err := queryVersion(i.db)
 	if err != nil {
 		return fmt.Errorf("error querying postgresql version: %w", err)
@@ -80,11 +80,11 @@ func (i *instance) SetupWithConnection(db *sql.DB) error {
 	return nil
 }
 
-func (i *instance) getDB() *sql.DB {
+func (i *Instance) getDB() *sql.DB {
 	return i.db
 }
 
-func (i *instance) Close() error {
+func (i *Instance) Close() error {
 	return i.db.Close()
 }
 

--- a/collector/pg_buffercache_summary.go
+++ b/collector/pg_buffercache_summary.go
@@ -91,7 +91,7 @@ var (
 
 // Update implements Collector
 // It is called by the Prometheus registry when collecting metrics.
-func (c BuffercacheSummaryCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c BuffercacheSummaryCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	// pg_buffercache_summary is only in v16, and we don't need support for earlier currently.
 	if !instance.version.GE(semver.MustParse("16.0.0")) {
 		return nil

--- a/collector/pg_buffercache_summary_test.go
+++ b/collector/pg_buffercache_summary_test.go
@@ -30,7 +30,7 @@ func TestBuffercacheSummaryCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("16.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("16.0.0")}
 
 	columns := []string{
 		"buffers_used",

--- a/collector/pg_database.go
+++ b/collector/pg_database.go
@@ -76,7 +76,7 @@ var (
 // each database individually. This is because we can't filter the
 // list of databases in the query because the list of excluded
 // databases is dynamic.
-func (c PGDatabaseCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGDatabaseCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	// Query the list of databases
 	rows, err := db.QueryContext(ctx,

--- a/collector/pg_database_test.go
+++ b/collector/pg_database_test.go
@@ -29,7 +29,7 @@ func TestPGDatabaseCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	mock.ExpectQuery(sanitizeQuery(pgDatabaseQuery)).WillReturnRows(sqlmock.NewRows([]string{"datname", "datconnlimit"}).
 		AddRow("postgres", 15))
@@ -70,7 +70,7 @@ func TestPGDatabaseCollectorNullMetric(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	mock.ExpectQuery(sanitizeQuery(pgDatabaseQuery)).WillReturnRows(sqlmock.NewRows([]string{"datname", "datconnlimit"}).
 		AddRow("postgres", nil))

--- a/collector/pg_database_wraparound.go
+++ b/collector/pg_database_wraparound.go
@@ -61,7 +61,7 @@ var (
 	`
 )
 
-func (c *PGDatabaseWraparoundCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGDatabaseWraparoundCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		databaseWraparoundQuery)

--- a/collector/pg_database_wraparound_test.go
+++ b/collector/pg_database_wraparound_test.go
@@ -28,7 +28,7 @@ func TestPGDatabaseWraparoundCollector(t *testing.T) {
 		t.Fatalf("Error opening a stub db connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	columns := []string{
 		"datname",
 		"age_datfrozenxid",

--- a/collector/pg_locks.go
+++ b/collector/pg_locks.go
@@ -88,7 +88,7 @@ var (
 
 // Update implements Collector and exposes database locks.
 // It is called by the Prometheus registry when collecting metrics.
-func (c PGLocksCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGLocksCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	// Query the list of databases
 	rows, err := db.QueryContext(ctx,

--- a/collector/pg_locks_test.go
+++ b/collector/pg_locks_test.go
@@ -29,7 +29,7 @@ func TestPGLocksCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	rows := sqlmock.NewRows([]string{"datname", "mode", "count"}).
 		AddRow("test", "exclusivelock", 42)

--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -61,7 +61,7 @@ AND pid <> pg_backend_pid();
 	`
 )
 
-func (PGLongRunningTransactionsCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (PGLongRunningTransactionsCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		longRunningTransactionsQuery)

--- a/collector/pg_long_running_transactions_test.go
+++ b/collector/pg_long_running_transactions_test.go
@@ -28,7 +28,7 @@ func TestPGLongRunningTransactionsCollector(t *testing.T) {
 		t.Fatalf("Error opening a stub db connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	columns := []string{
 		"transactions",
 		"age_in_seconds",

--- a/collector/pg_postmaster.go
+++ b/collector/pg_postmaster.go
@@ -47,7 +47,7 @@ var (
 	pgPostmasterQuery = "SELECT extract(epoch from pg_postmaster_start_time) from pg_postmaster_start_time();"
 )
 
-func (c *PGPostmasterCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGPostmasterCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	row := db.QueryRowContext(ctx,
 		pgPostmasterQuery)

--- a/collector/pg_postmaster_test.go
+++ b/collector/pg_postmaster_test.go
@@ -29,7 +29,7 @@ func TestPgPostmasterCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	mock.ExpectQuery(sanitizeQuery(pgPostmasterQuery)).WillReturnRows(sqlmock.NewRows([]string{"pg_postmaster_start_time"}).
 		AddRow(1685739904))
@@ -65,7 +65,7 @@ func TestPgPostmasterCollectorNullTime(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	mock.ExpectQuery(sanitizeQuery(pgPostmasterQuery)).WillReturnRows(sqlmock.NewRows([]string{"pg_postmaster_start_time"}).
 		AddRow(nil))

--- a/collector/pg_process_idle.go
+++ b/collector/pg_process_idle.go
@@ -44,7 +44,7 @@ var pgProcessIdleSeconds = prometheus.NewDesc(
 	prometheus.Labels{},
 )
 
-func (PGProcessIdleCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (PGProcessIdleCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	row := db.QueryRowContext(ctx,
 		`WITH

--- a/collector/pg_replication.go
+++ b/collector/pg_replication.go
@@ -74,7 +74,7 @@ var (
 	GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) as last_replay`
 )
 
-func (c *PGReplicationCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGReplicationCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	row := db.QueryRowContext(ctx,
 		pgReplicationQuery,

--- a/collector/pg_replication_slot.go
+++ b/collector/pg_replication_slot.go
@@ -108,7 +108,7 @@ var (
 	FROM pg_replication_slots;`
 )
 
-func (PGReplicationSlotCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (PGReplicationSlotCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	query := pgReplicationSlotQuery
 	abovePG13 := instance.version.GTE(semver.MustParse("13.0.0"))
 	if abovePG13 {

--- a/collector/pg_replication_slot_test.go
+++ b/collector/pg_replication_slot_test.go
@@ -30,7 +30,7 @@ func TestPgReplicationSlotCollectorActive(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
@@ -73,7 +73,7 @@ func TestPgReplicationSlotCollectorInActive(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
@@ -116,7 +116,7 @@ func TestPgReplicationSlotCollectorActiveNil(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).
@@ -157,7 +157,7 @@ func TestPgReplicationSlotCollectorTestNilValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"slot_name", "slot_type", "current_wal_lsn", "confirmed_flush_lsn", "active", "safe_wal_size", "wal_status"}
 	rows := sqlmock.NewRows(columns).

--- a/collector/pg_replication_test.go
+++ b/collector/pg_replication_test.go
@@ -29,7 +29,7 @@ func TestPgReplicationCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{"lag", "is_replica", "last_replay"}
 	rows := sqlmock.NewRows(columns).

--- a/collector/pg_roles.go
+++ b/collector/pg_roles.go
@@ -53,7 +53,7 @@ var (
 
 // Update implements Collector and exposes roles connection limits.
 // It is called by the Prometheus registry when collecting metrics.
-func (c PGRolesCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGRolesCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	// Query the list of databases
 	rows, err := db.QueryContext(ctx,

--- a/collector/pg_roles_test.go
+++ b/collector/pg_roles_test.go
@@ -29,7 +29,7 @@ func TestPGRolesCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	mock.ExpectQuery(sanitizeQuery(pgRolesConnectionLimitsQuery)).WillReturnRows(sqlmock.NewRows([]string{"rolname", "rolconnlimit"}).
 		AddRow("postgres", 15))

--- a/collector/pg_stat_activity_autovacuum.go
+++ b/collector/pg_stat_activity_autovacuum.go
@@ -53,7 +53,7 @@ var (
 	`
 )
 
-func (PGStatActivityAutovacuumCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (PGStatActivityAutovacuumCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		statActivityAutovacuumQuery)

--- a/collector/pg_stat_activity_autovacuum_test.go
+++ b/collector/pg_stat_activity_autovacuum_test.go
@@ -28,7 +28,7 @@ func TestPGStatActivityAutovacuumCollector(t *testing.T) {
 		t.Fatalf("Error opening a stub db connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	columns := []string{
 		"relname",
 		"timestamp_seconds",

--- a/collector/pg_stat_bgwriter.go
+++ b/collector/pg_stat_bgwriter.go
@@ -124,7 +124,7 @@ var (
 	FROM pg_stat_bgwriter;`
 )
 
-func (PGStatBGWriterCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (PGStatBGWriterCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	if instance.version.GE(semver.MustParse("17.0.0")) {
 		db := instance.getDB()
 		row := db.QueryRowContext(ctx, statBGWriterQueryAfter17)

--- a/collector/pg_stat_bgwriter_test.go
+++ b/collector/pg_stat_bgwriter_test.go
@@ -30,7 +30,7 @@ func TestPGStatBGWriterCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"checkpoints_timed",
@@ -96,7 +96,7 @@ func TestPGStatBGWriterCollectorNullValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"checkpoints_timed",

--- a/collector/pg_stat_checkpointer.go
+++ b/collector/pg_stat_checkpointer.go
@@ -107,7 +107,7 @@ var (
 	FROM pg_stat_checkpointer;`
 )
 
-func (c PGStatCheckpointerCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGStatCheckpointerCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 
 	before17 := instance.version.LT(semver.MustParse("17.0.0"))

--- a/collector/pg_stat_checkpointer_test.go
+++ b/collector/pg_stat_checkpointer_test.go
@@ -31,7 +31,7 @@ func TestPGStatCheckpointerCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("17.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("17.0.0")}
 
 	columns := []string{
 		"num_timed",
@@ -93,7 +93,7 @@ func TestPGStatCheckpointerCollectorNullValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("17.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("17.0.0")}
 
 	columns := []string{
 		"num_timed",

--- a/collector/pg_stat_database.go
+++ b/collector/pg_stat_database.go
@@ -223,7 +223,7 @@ func statDatabaseQuery(columns []string) string {
 	return fmt.Sprintf("SELECT %s FROM pg_stat_database;", strings.Join(columns, ","))
 }
 
-func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGStatDatabaseCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 
 	columns := []string{

--- a/collector/pg_stat_database_test.go
+++ b/collector/pg_stat_database_test.go
@@ -32,7 +32,7 @@ func TestPGStatDatabaseCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("14.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("14.0.0")}
 
 	columns := []string{
 		"datid",
@@ -143,7 +143,7 @@ func TestPGStatDatabaseCollectorNullValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing time: %s", err)
 	}
-	inst := &instance{db: db, version: semver.MustParse("14.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("14.0.0")}
 
 	columns := []string{
 		"datid",
@@ -265,7 +265,7 @@ func TestPGStatDatabaseCollectorRowLeakTest(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("14.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("14.0.0")}
 
 	columns := []string{
 		"datid",
@@ -434,7 +434,7 @@ func TestPGStatDatabaseCollectorTestNilStatReset(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("14.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("14.0.0")}
 
 	columns := []string{
 		"datid",

--- a/collector/pg_stat_progress_vacuum.go
+++ b/collector/pg_stat_progress_vacuum.go
@@ -114,7 +114,7 @@ var (
 		pg_database d ON s.datid = d.oid`
 )
 
-func (c *PGStatProgressVacuumCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGStatProgressVacuumCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		statProgressVacuumQuery)

--- a/collector/pg_stat_progress_vacuum_test.go
+++ b/collector/pg_stat_progress_vacuum_test.go
@@ -29,7 +29,7 @@ func TestPGStatProgressVacuumCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"datname", "relname", "phase", "heap_blks_total", "heap_blks_scanned",
@@ -85,7 +85,7 @@ func TestPGStatProgressVacuumCollectorNullValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"datname", "relname", "phase", "heap_blks_total", "heap_blks_scanned",

--- a/collector/pg_stat_statements.go
+++ b/collector/pg_stat_statements.go
@@ -173,7 +173,7 @@ const (
 	LIMIT 100;`
 )
 
-func (c PGStatStatementsCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGStatStatementsCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	var queryTemplate string
 	switch {
 	case instance.version.GE(semver.MustParse("17.0.0")):

--- a/collector/pg_stat_statements_test.go
+++ b/collector/pg_stat_statements_test.go
@@ -31,7 +31,7 @@ func TestPGStateStatementsCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("12.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("12.0.0")}
 
 	columns := []string{"user", "datname", "queryid", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -74,7 +74,7 @@ func TestPGStateStatementsCollectorWithStatement(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("12.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("12.0.0")}
 
 	columns := []string{"user", "datname", "queryid", "LEFT(pg_stat_statements.query, 100) as query", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -118,7 +118,7 @@ func TestPGStateStatementsCollectorNull(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"user", "datname", "queryid", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -161,7 +161,7 @@ func TestPGStateStatementsCollectorNullWithStatement(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"user", "datname", "queryid", "LEFT(pg_stat_statements.query, 200) as query", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -205,7 +205,7 @@ func TestPGStateStatementsCollectorNewPG(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"user", "datname", "queryid", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -248,7 +248,7 @@ func TestPGStateStatementsCollectorNewPGWithStatement(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("13.3.7")}
+	inst := &Instance{db: db, version: semver.MustParse("13.3.7")}
 
 	columns := []string{"user", "datname", "queryid", "LEFT(pg_stat_statements.query, 300) as query", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -292,7 +292,7 @@ func TestPGStateStatementsCollector_PG17(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("17.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("17.0.0")}
 
 	columns := []string{"user", "datname", "queryid", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).
@@ -335,7 +335,7 @@ func TestPGStateStatementsCollector_PG17_WithStatement(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db, version: semver.MustParse("17.0.0")}
+	inst := &Instance{db: db, version: semver.MustParse("17.0.0")}
 
 	columns := []string{"user", "datname", "queryid", "LEFT(pg_stat_statements.query, 300) as query", "calls_total", "seconds_total", "rows_total", "block_read_seconds_total", "block_write_seconds_total"}
 	rows := sqlmock.NewRows(columns).

--- a/collector/pg_stat_user_tables.go
+++ b/collector/pg_stat_user_tables.go
@@ -192,7 +192,7 @@ var (
 		pg_stat_user_tables`
 )
 
-func (c *PGStatUserTablesCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGStatUserTablesCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		statUserTablesQuery)

--- a/collector/pg_stat_user_tables_test.go
+++ b/collector/pg_stat_user_tables_test.go
@@ -30,7 +30,7 @@ func TestPGStatUserTablesCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	lastVacuumTime, err := time.Parse("2006-01-02Z", "2023-06-02Z")
 	if err != nil {
@@ -152,7 +152,7 @@ func TestPGStatUserTablesCollectorNullValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"datname",

--- a/collector/pg_stat_walreceiver.go
+++ b/collector/pg_stat_walreceiver.go
@@ -119,7 +119,7 @@ receive_start_tli,
 	`
 )
 
-func (c *PGStatWalReceiverCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGStatWalReceiverCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	hasFlushedLSNRows, err := db.QueryContext(ctx, pgStatWalColumnQuery)
 	if err != nil {

--- a/collector/pg_stat_walreceiver_test.go
+++ b/collector/pg_stat_walreceiver_test.go
@@ -33,7 +33,7 @@ func TestPGStatWalReceiverCollectorWithFlushedLSN(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	infoSchemaColumns := []string{
 		"column_name",
 	}
@@ -116,7 +116,7 @@ func TestPGStatWalReceiverCollectorWithNoFlushedLSN(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	infoSchemaColumns := []string{
 		"column_name",
 	}

--- a/collector/pg_statio_user_indexes.go
+++ b/collector/pg_statio_user_indexes.go
@@ -59,7 +59,7 @@ var (
 	`
 )
 
-func (c *PGStatioUserIndexesCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c *PGStatioUserIndexesCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		statioUserIndexesQuery)

--- a/collector/pg_statio_user_indexes_test.go
+++ b/collector/pg_statio_user_indexes_test.go
@@ -28,7 +28,7 @@ func TestPgStatioUserIndexesCollector(t *testing.T) {
 		t.Fatalf("Error opening a stub db connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	columns := []string{
 		"schemaname",
 		"relname",
@@ -71,7 +71,7 @@ func TestPgStatioUserIndexesCollectorNull(t *testing.T) {
 		t.Fatalf("Error opening a stub db connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	columns := []string{
 		"schemaname",
 		"relname",

--- a/collector/pg_statio_user_tables.go
+++ b/collector/pg_statio_user_tables.go
@@ -100,7 +100,7 @@ var (
 	FROM pg_statio_user_tables`
 )
 
-func (PGStatIOUserTablesCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (PGStatIOUserTablesCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	rows, err := db.QueryContext(ctx,
 		statioUserTablesQuery)

--- a/collector/pg_statio_user_tables_test.go
+++ b/collector/pg_statio_user_tables_test.go
@@ -29,7 +29,7 @@ func TestPGStatIOUserTablesCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"datname",
@@ -96,7 +96,7 @@ func TestPGStatIOUserTablesCollectorNullValues(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{
 		"datname",

--- a/collector/pg_wal.go
+++ b/collector/pg_wal.go
@@ -60,7 +60,7 @@ var (
 		WHERE name ~ '^[0-9A-F]{24}$'`
 )
 
-func (c PGWALCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGWALCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 	row := db.QueryRowContext(ctx,
 		pgWALQuery,

--- a/collector/pg_wal_test.go
+++ b/collector/pg_wal_test.go
@@ -29,7 +29,7 @@ func TestPgWALCollector(t *testing.T) {
 	}
 	defer db.Close()
 
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 
 	columns := []string{"segments", "size"}
 	rows := sqlmock.NewRows(columns).

--- a/collector/pg_xlog_location.go
+++ b/collector/pg_xlog_location.go
@@ -51,7 +51,7 @@ var (
 	`
 )
 
-func (c PGXlogLocationCollector) Update(ctx context.Context, instance *instance, ch chan<- prometheus.Metric) error {
+func (c PGXlogLocationCollector) Update(ctx context.Context, instance *Instance, ch chan<- prometheus.Metric) error {
 	db := instance.getDB()
 
 	// xlog was renmaed to WAL in PostgreSQL 10

--- a/collector/pg_xlog_location_test.go
+++ b/collector/pg_xlog_location_test.go
@@ -28,7 +28,7 @@ func TestPGXlogLocationCollector(t *testing.T) {
 		t.Fatalf("Error opening a stub db connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &Instance{db: db}
 	columns := []string{
 		"bytes",
 	}

--- a/collector/probe.go
+++ b/collector/probe.go
@@ -26,7 +26,7 @@ type ProbeCollector struct {
 	registry   *prometheus.Registry
 	collectors map[string]Collector
 	logger     *slog.Logger
-	instance   *instance
+	instance   *Instance
 }
 
 func NewProbeCollector(logger *slog.Logger, excludeDatabases []string, registry *prometheus.Registry, dsn config.DSN) (*ProbeCollector, error) {

--- a/collector/probe.go
+++ b/collector/probe.go
@@ -57,7 +57,7 @@ func NewProbeCollector(logger *slog.Logger, excludeDatabases []string, registry 
 		}
 	}
 
-	instance, err := newInstance(dsn.GetConnectionString())
+	instance, err := NewInstance(dsn.GetConnectionString())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Background

The current behavior of the exporter is to open a new database connection on every scrape.

First, here is where the default metrics collector and new-style collectors are registered:
https://github.com/planetscale/postgres_exporter/blob/198454cc9e56141d5cc422149755fe8e80b3eeea/cmd/postgres_exporter/main.go#L126
https://github.com/planetscale/postgres_exporter/blob/198454cc9e56141d5cc422149755fe8e80b3eeea/cmd/postgres_exporter/main.go#L143

Prometheus may run these collectors in parallel. Additionally, the `collectors` package is set up to support concurrent scrapes:
https://github.com/planetscale/postgres_exporter/blob/198454cc9e56141d5cc422149755fe8e80b3eeea/collector/collector.go#L171-L176

No doubt it's useful for some to have the default and new-style metrics be collected concurrently, and to be able to support concurrent srapes.

## Changes

But for PlanetScale, our metric collection system does not scrape the same endpoint concurrently, so concurrent scrapes aren't useful for us. We can also live without whatever time is gained by having default and new-style metrics be collected concurrently: our scrape timeout is 10s, and we expect metrics to be collected much faster than that. If not, then we probably have other problems we need to look at.

Additionally we want to consume as few customer connections as possible. So having the option of using a single, shared connection between default and new-style metrics is good for us. Additionally, if customers have used up all their connections, having each scrape create a new db conn might mean we can't produce metrics. So, having the option to use a single, shared, _persistent_ connection is doubly useful.

## Validation

Create a role with a connection limit of 1:
```postgresql
CREATE ROLE postgres_exporter WITH LOGIN CONNECTION LIMIT 1;
GRANT pg_monitor TO postgres_exporter;
GRANT CONNECT ON DATABASE postgres TO postgres_exporter;
```

### With `--no-concurrent-scrape`

Start the exporter with concurrent scraping disabled:
```bash
DATA_SOURCE_NAME="postgresql://postgres_exporter@127.0.0.1:5432/postgres?sslmode=disable" ./postgres_exporter --no-concurrent-scrape --log.level=info
```

Scraping metrics shows no errors in output.

### With `--concurrent-scrape`

Repeat with `--concurrent-scrape`, shows this error:

> time=2025-09-06T20:56:44.568-04:00 level=ERROR source=collector.go:195 msg="Error opening connection to database" err="error querying postgresql version: pq: too many connections for role \"postgres_exporter\""

### Connection resilience

Verified that `--no-concurrent-scrape` is resilient to Postgres connection resets. After a connection reset, the exporter will log an error:

> time=2025-09-06T22:44:06.172-04:00 level=ERROR source=collector.go:180 msg="Error creating instance" err="driver: bad connection"

But the connection will be recreated and the scrape (or the next scrape anyway) will succeed. Behavior seems similar to `master`.