### PR TITLE
Revert "Exclude the metrics fetching session's data from pg_stat_activity (#1185)"

### DIFF
--- a/cmd/postgres_exporter/queries.go
+++ b/cmd/postgres_exporter/queries.go
@@ -142,7 +142,6 @@ var queryOverrides = map[string][]OverrideQuery{
 					count(*) AS count,
 					MAX(EXTRACT(EPOCH FROM now() - xact_start))::float AS max_tx_duration
 				FROM pg_stat_activity
-				WHERE pid <> pg_backend_pid()
 				GROUP BY datname,state,usename,application_name,backend_type,wait_event_type,wait_event) AS tmp2
 				ON tmp.state = tmp2.state AND pg_database.datname = tmp2.datname
 			`,
@@ -157,9 +156,7 @@ var queryOverrides = map[string][]OverrideQuery{
 				application_name,
 				COALESCE(count(*),0) AS count,
 				COALESCE(MAX(EXTRACT(EPOCH FROM now() - xact_start))::float,0) AS max_tx_duration
-			FROM pg_stat_activity
-			WHERE procpid <> pg_backend_pid()
-			GROUP BY datname,usename,application_name
+			FROM pg_stat_activity GROUP BY datname,usename,application_name
 			`,
 		},
 	},

--- a/collector/pg_long_running_transactions.go
+++ b/collector/pg_long_running_transactions.go
@@ -56,8 +56,7 @@ var (
 FROM pg_catalog.pg_stat_activity
 WHERE state IS DISTINCT FROM 'idle'
 AND query NOT LIKE 'autovacuum:%'
-AND pg_stat_activity.xact_start IS NOT NULL
-AND pid <> pg_backend_pid();
+AND pg_stat_activity.xact_start IS NOT NULL;
 	`
 )
 

--- a/collector/pg_process_idle.go
+++ b/collector/pg_process_idle.go
@@ -56,7 +56,6 @@ func (PGProcessIdleCollector) Update(ctx context.Context, instance *Instance, ch
 				COUNT(*) AS process_idle_seconds_count
 				FROM pg_stat_activity
 				WHERE state ~ '^idle'
-				AND pid <> pg_backend_pid();
 				GROUP BY state, application_name
 			),
 			buckets AS (
@@ -73,7 +72,6 @@ func (PGProcessIdleCollector) Update(ctx context.Context, instance *Instance, ch
 				FROM
 				pg_stat_activity,
 				UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
-				WHERE pid <> pg_backend_pid()
 				GROUP BY state, application_name, le
 				ORDER BY state, application_name, le
 			)


### PR DESCRIPTION
This reverts commit 198454cc9e56141d5cc422149755fe8e80b3eeea.

https://github.com/prometheus-community/postgres_exporter/pull/1185 appears to have broken some things:

> {"time":"2025-09-10T03:57:53.677992156Z","level":"ERROR","source":"collector.go:223","msg":"collector failed","name":"long_running_transactions","duration_seconds":0.010053746,"err":"sql: Scan error on column index 1, name \"oldest_timestamp_seconds\": converting NULL to float64 is unsupported"}
> {"time":"2025-09-10T03:57:53.679318983Z","level":"ERROR","source":"collector.go:223","msg":"collector failed","name":"process_idle","duration_seconds":0.011370523,"err":"pq: syntax error at or near \";\""}